### PR TITLE
Remove irrelevant duplicates

### DIFF
--- a/scripts/deduplicate.R
+++ b/scripts/deduplicate.R
@@ -11,5 +11,17 @@ deduplicate <- function(df){
     group_by(doi) %>%
     mutate(dup_id = cur_group_id())
 
+  # Merge duplicate rows
+  for(i in 1:max(doi_set$dup_id)){
+    dup_set <- doi_set[which(doi_set$dup_id == i),]
+    needed_row <- which(dup_set$unique_record == 1)
+    needed_index <- dup_set$index[needed_row]
+    df_row <- which(df$index == needed_index)
+    
+    # Determine which row needs a one
+    
+    # Remove duplicate
+  }
+
   return(df)
 }


### PR DESCRIPTION
This PR adds a script that contains the start of a function that removes duplicates.
While deduplicating, the inclusion information per subject will be passed on the the deduplicated row. 

For example: Record A is included in both Anxiety and Depression, but not in substance abuse
1. anxiety_included == 1, depression_included == NA, sub_ab_included == NA, final_included == 1
2. anxiety_included == NA, depression_included == 1, sub_ab_included == NA, final_included == 1
3. anxiety_included == NA, depression_included == NA, sub_ab_included == 0, final_included == 0

This should become a single row
anxiety_included == 1, depression_included == 1, sub_ab_included == 0, final_included == 1