### PR TITLE
Create requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+R version 4.1.1 (2021-08-10)
+
+base packages:
+[1] stats     graphics  grDevices utils     datasets  methods   base
+
+other attached packages:
+ [1] janitor_2.1.0   forcats_0.5.1   stringr_1.4.0   dplyr_1.0.7    
+ [5] purrr_0.3.4     readr_2.0.1     tidyr_1.1.3     tibble_3.1.3   
+ [9] ggplot2_3.3.5   tidyverse_1.3.1 writexl_1.4.0   readxl_1.3.1   
+
+loaded via a namespace (and not attached):
+ [1] Rcpp_1.0.7       cellranger_1.1.0 pillar_1.6.2     compiler_4.1.1  
+ [5] dbplyr_2.1.1     tools_4.1.1      lubridate_1.7.10 jsonlite_1.7.2  
+ [9] lifecycle_1.0.0  gtable_0.3.0     pkgconfig_2.0.3  rlang_0.4.11    
+[13] reprex_2.0.1     cli_3.0.1        rstudioapi_0.13  DBI_1.1.1       
+[17] haven_2.4.3      xml2_1.3.2       withr_2.4.2      httr_1.4.2      
+[21] fs_1.5.0         generics_0.1.0   vctrs_0.3.8      hms_1.1.0       
+[25] grid_4.1.1       tidyselect_1.1.1 snakecase_0.11.0 glue_1.4.2      
+[29] R6_2.5.0         fansi_0.5.0      tzdb_0.1.2       modelr_0.1.8    
+[33] magrittr_2.0.1   backports_1.2.1  scales_1.1.1     ellipsis_0.3.2  
+[37] rvest_1.0.1      assertthat_0.2.1 colorspace_2.0-2 utf8_1.2.2      
+[41] stringi_1.7.3    munsell_0.5.0    broom_0.7.9      crayon_1.4.1 


### PR DESCRIPTION
This commit adds a file, `requirements.txt`, which details which R version and packages are used within the megameta post-processing.

This PR closes #17.
