### PR TITLE
Add function to print information on datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ It is possible to improve the speed of the doi retrieval by using the following 
    records aren't split evenly, the last chunk might be smaller than the others.
 2. For each chunk, create a copy of the `chunk_0.py` file, and place it in the
    `split` folder. Change the name `chunk_0.py` to `chunk_1.py`, `chunk_2.py`,
-   etc, for each created chunk. 
-3. Within each file, change `script_number` = "0" to `script_number` = "1", 
+   etc, for each created chunk.
+3. Within each file, change `script_number` = "0" to `script_number` = "1",
    `script_number` = "2", etc.
 4. Run each `chunk_*.py` file in the `split` folder simultaneously from a
    separate console. The script stores the console output to a respective
@@ -193,6 +193,7 @@ A dataset with only those records which have a 1 in anxiety_included_corrected
 -  `change_test_file_names.R` - With this script the filenames of the test files are converted to the empirical datafile names.
 -  `merge_datasets.R` - This script contains a function to merge the datasets. An unique included column is added for each dataset before the merge.
 -  `composite_label.R` - This script contains a function to create a column with the final inclusions.
+- `print_information_datasets.R` - This script contains a function to print information on datasets.
 -  `identify_duplicates.R` - This script contains a function to identify duplicate records in the dataset.
 -  `deduplicate_doi.R` - This script contains a function to deduplicate the records, based on doi, while maintaining all information.
 -  `quality_check.R` - This script corrects those labels which were incorrect according to 2 quality checks: Quality check 1 (incorrectly assigned irrelevant), Quality check 2 (incorrectly assigned relevant).

--- a/scripts/deduplicate_conservative.R
+++ b/scripts/deduplicate_conservative.R
@@ -334,21 +334,23 @@ deduplicate_conservative <- function(df,
     } # Close else statement for megameta = FALSE
       
     # Print information about the deduplication process
-      cat(
-        paste(
-          "In total",
-          max(dup_sets$dup_id),
-          "sets were deduplicated conservatively, of which: \n",
-          n_labeled_dupes,
-          "sets had at least one label \n",
-          n_no_label_dupes,
-          "sets had no label at all \n"
-        )
+    cat(
+      paste0(
+        "In total ",
+        max(doi_set$dup_id),
+        " sets were deduplicated conservatively (based on ",
+        all_cons_cols, 
+        ") of which: \n",
+        n_labeled_dupes,
+        " (",
+        round(n_labeled_dupes/max(doi_set$dup_id)*100, 2),
+        "%) sets had at least one label \n",
+        n_no_label_dupes,
+        " (",
+        round(n_no_label_dupes/max(doi_set$dup_id)*100, 2),
+        "%) sets had no label at all."
       )
-      
-      return(df)
-
-      # In case there are no identified duplicates through the conservative way:
+    )# In case there are no identified duplicates through the conservative way:
       
     } else {
       

--- a/scripts/deduplicate_doi.R
+++ b/scripts/deduplicate_doi.R
@@ -219,14 +219,18 @@ deduplicate_doi <- function(df, megameta) {
   
   # Print information about the deduplication process
   cat(
-    paste(
-      "In total",
+    paste0(
+      "In total ",
       max(doi_set$dup_id),
-      "sets were deduplicated based on doi, of which: \n",
+      " sets were deduplicated based on doi, of which: \n",
       n_labeled_dupes,
-      "sets had at least one label \n",
+      " (",
+      round(n_labeled_dupes/max(doi_set$dup_id)*100, 2),
+      "%) sets had at least one label. \n",
       n_no_label_dupes,
-      "sets had no label at all \n"
+      " (",
+      round(n_no_label_dupes/max(doi_set$dup_id)*100, 2),
+      "%) sets had no label at all."
     )
   )
   

--- a/scripts/master_script_merging_after_asreview.R
+++ b/scripts/master_script_merging_after_asreview.R
@@ -45,17 +45,17 @@ OUTPUT_PATH <- "output/"
 depression <- read_xlsx(paste0(DATA_PATH, "depression", RESULTS_DATA_PATH))
 
 ## Printing information, change the `included` if necessary.
-included_excluded(df = depression,name = "depression", included_column = depression$included)
+info_datasets(df = depression, name = "depression", included_column = depression$included)
 
 # SUBSTANCE
 substance <- read_xlsx(paste0(DATA_PATH, "substance", RESULTS_DATA_PATH))
 ## Printing information, change the `included` if necessary.
-included_excluded(df = substance,name = "substance", included_column = substance$included)
+info_datasets(df = substance, name = "substance", included_column = substance$included)
 
 # ANXIETY
 anxiety <- read_xlsx(paste0(DATA_PATH, "anxiety", RESULTS_DATA_PATH))
 ## Printing information, change the `included` if necessary.
-included_excluded(df = anxiety,name = "anxiety", included_column = anxiety$included)
+info_datasets(df = anxiety, name = "anxiety", included_column = anxiety$included)
 
 ##### DATA WRANGLING ######
 
@@ -70,7 +70,7 @@ df <- merge_datasets(depression, substance, anxiety)
 df <- composite_label(df)
 
 ## Print information
-included_excluded(df = df,name = "merged", included_column = df$composite_label)
+info_datasets(df = df, name = "merged", included_column = df$composite_label)
 
 
 #### PREPARE FOR EXPORT TO DOI RETRIEVAL ####

--- a/scripts/master_script_merging_after_asreview.R
+++ b/scripts/master_script_merging_after_asreview.R
@@ -23,6 +23,7 @@ library(janitor)   # Deduplication
 # LOAD FUNCTIONS
 source("scripts/merge_datasets.R") # Merges all three input datasets
 source("scripts/composite_label.R") # Adds a column indicating final_inclusions
+source("scripts/print_information_datasets.R") # Function to print information.
 
 # CREATE DIRECTORIES
 ## Output
@@ -39,9 +40,22 @@ OUTPUT_PATH <- "output/"
 
 ## If necessary, change below to your specific path(s):
 # Importing Results Data
+
+#DEPRESSION
 depression <- read_xlsx(paste0(DATA_PATH, "depression", RESULTS_DATA_PATH))
+
+## Printing information, change the `included` if necessary.
+included_excluded(df = depression,name = "depression", included_column = depression$included)
+
+# SUBSTANCE
 substance <- read_xlsx(paste0(DATA_PATH, "substance", RESULTS_DATA_PATH))
+## Printing information, change the `included` if necessary.
+included_excluded(df = substance,name = "substance", included_column = substance$included)
+
+# ANXIETY
 anxiety <- read_xlsx(paste0(DATA_PATH, "anxiety", RESULTS_DATA_PATH))
+## Printing information, change the `included` if necessary.
+included_excluded(df = anxiety,name = "anxiety", included_column = anxiety$included)
 
 ##### DATA WRANGLING ######
 
@@ -51,8 +65,13 @@ df <- merge_datasets(depression, substance, anxiety)
 
 # FINAL INCLUSIONS
 ## Next, let's add a column of composite_label.
-## Composite_label simply indicates whether the record was included.
+## Composite_label simply indicates whether the record was included in at least
+## one subject.
 df <- composite_label(df)
+
+## Print information
+included_excluded(df = df,name = "merged", included_column = df$composite_label)
+
 
 #### PREPARE FOR EXPORT TO DOI RETRIEVAL ####
 

--- a/scripts/master_script_quality_check.R
+++ b/scripts/master_script_quality_check.R
@@ -89,12 +89,36 @@ df <- quality_check(df)
 ## Check how many values were changed
 
 # Quality check 1:
-print(paste("The number of changed labels through quality check 1 (irrelevant turned relevant) is",
-length(which(!is.na(df$`quality_check_1(0->1)`)))))
+cat(
+  paste0(
+    "The number of changed labels through quality check 1 (irrelevant turned relevant) is ",
+    nrow(df %>% filter(!is.na(
+      `quality_check_1(0->1)`
+    ))),
+    # number of changed labels.
+    " (",
+    round(nrow(df %>% filter(
+      !is.na(`quality_check_1(0->1)`)
+    )) / nrow(df) * 100, 2),
+    "%)." # percentage of changed labels.
+  )
+)
 
 # Quality check 2:
-print(paste("The number of changed labels through quality check 2 (relevant turned irrelevant) is",
-length(which(!is.na(df$`quality_check_2(1->0)`)))))
+cat(
+  paste0(
+    "The number of changed labels through quality check 2 (relevant turned irrelevant) is ",
+    nrow(df %>% filter(!is.na(
+      `quality_check_2(1->0)`
+    ))),
+    # number of changed labels.
+    " (",
+    round(nrow(df %>% filter(
+      !is.na(`quality_check_2(1->0)`)
+    )) / nrow(df) * 100, 2),
+    "%)." # percentage of changed labels.
+  )
+)
 
 #### Preparation for exportation ####
 

--- a/scripts/master_script_quality_check.R
+++ b/scripts/master_script_quality_check.R
@@ -89,11 +89,11 @@ df <- quality_check(df)
 ## Check how many values were changed
 
 # Quality check 1:
-print(paste("The number of changed labels through quality check 1 is",
+print(paste("The number of changed labels through quality check 1 (irrelevant turned relevant) is",
 length(which(!is.na(df$`quality_check_1(0->1)`)))))
 
 # Quality check 2:
-print(paste("The number of changed labels through quality check 2 is",
+print(paste("The number of changed labels through quality check 2 (relevant turned irrelevant) is",
 length(which(!is.na(df$`quality_check_2(1->0)`)))))
 
 #### Preparation for exportation ####

--- a/scripts/print_information_datasets.R
+++ b/scripts/print_information_datasets.R
@@ -6,8 +6,15 @@ included_excluded <- function (df,name, included_column){
   cat(paste("The", name, "dataset contains", nrow(df), "records.\n",
             "Of which there are: \n", 
             nrow(df %>% filter(included_column == 1)), "included records. \n",
-            nrow(df %>% filter(included_column == 0)), "excluded records."
+            nrow(df %>% filter(included_column == 0)), "excluded records.",
+            "\n \n",
+            "This dataset also contains:\n",
+            length(which(!is.na(df$title))), "/", nrow(df), "titles. \n",
+            length(which(!is.na(df$abstract))), "/", nrow(df), "abstracts. \n",
+            length(which(!is.na(df$doi))), "/", nrow(df), "doi's. \n"
   ))
+  
+  
   
   
 }

--- a/scripts/print_information_datasets.R
+++ b/scripts/print_information_datasets.R
@@ -1,20 +1,20 @@
 ######## Retrieve and print information ############
 
 ### Print information on inclusions and exclusions.
-included_excluded <- function (df,name, included_column){
+info_datasets <- function (df,name, included_column){
   
   cat(paste0("The ", name, " dataset contains ", nrow(df), " records.\n",
             "Of which there are: \n", 
-            nrow(df %>% filter(included_column == 1)), " included records. \n",
-            nrow(df %>% filter(included_column == 0)), " excluded records.",
+            nrow(df %>% filter(included_column == 1)), " included records. \n", # number of included records
+            nrow(df %>% filter(included_column == 0)), " excluded records.", # number of excluded records
             "\n \n",
             "This dataset also contains:\n",
-            length(which(!is.na(df$title))), "/", nrow(df), " titles, which is ", # number of titles
-            length(which(!is.na(df$title)))/nrow(df)*100,"%. \n",# percentage of present titles
-            length(which(!is.na(df$abstract))), "/", nrow(df), " abstracts, which is ", # number of abstracts
-            length(which(!is.na(df$abstract)))/nrow(df)*100 , "%. \n", # percentage of present abstracts
-            length(which(!is.na(df$doi))), "/", nrow(df), " doi's, which is ", # number of doi's
-            length(which(!is.na(df$doi)))/nrow(df)*100,"%. \n" # percentage of present doi's.
+            nrow(df %>% filter(!is.na(title))), "/", nrow(df), " titles, which is ", # number of titles
+            round(nrow(df %>% filter(!is.na(title)))/nrow(df)*100, 2),"%. \n",# percentage of present titles
+            nrow(df %>% filter(!is.na(abstract))), "/", nrow(df), " abstracts, which is ", # number of abstracts
+            round(nrow(df %>% filter(!is.na(abstract)))/nrow(df)*100, 2) , "%. \n", # percentage of present abstracts
+            nrow(df %>% filter(!is.na(doi))), "/", nrow(df), " doi's, which is ", # number of doi's
+            round(nrow(df %>% filter(!is.na(doi)))/nrow(df)*100, 2),"%. \n" # percentage of present doi's.
   ))
   
   

--- a/scripts/print_information_datasets.R
+++ b/scripts/print_information_datasets.R
@@ -1,0 +1,13 @@
+######## Retrieve and print information ############
+
+### Print information on inclusions and exclusions.
+included_excluded <- function (df,name, included_column){
+  
+  cat(paste("The", name, "dataset contains", nrow(df), "records.\n",
+            "Of which there are: \n", 
+            nrow(df %>% filter(included_column == 1)), "included records. \n",
+            nrow(df %>% filter(included_column == 0)), "excluded records."
+  ))
+  
+  
+}

--- a/scripts/print_information_datasets.R
+++ b/scripts/print_information_datasets.R
@@ -5,8 +5,11 @@ info_datasets <- function (df,name, included_column){
   
   cat(paste0("The ", name, " dataset contains ", nrow(df), " records.\n",
             "Of which there are: \n", 
-            nrow(df %>% filter(included_column == 1)), " included records. \n", # number of included records
-            nrow(df %>% filter(included_column == 0)), " excluded records.", # number of excluded records
+            nrow(df %>% filter(included_column == 1))," (", # number of included records
+            nrow(df %>% filter(included_column == 1))/nrow(df)*100, "%) included records. \n", # percentage of included records
+            nrow(df %>% filter(included_column == 0)), " (", # number of excluded records
+            nrow(df %>% filter(included_column == 0))/nrow(df)*100,"%) excluded records.", # percentage of excluded records
+            
             "\n \n",
             "This dataset also contains:\n",
             nrow(df %>% filter(!is.na(title))), "/", nrow(df), " titles, which is ", # number of titles

--- a/scripts/print_information_datasets.R
+++ b/scripts/print_information_datasets.R
@@ -3,15 +3,18 @@
 ### Print information on inclusions and exclusions.
 included_excluded <- function (df,name, included_column){
   
-  cat(paste("The", name, "dataset contains", nrow(df), "records.\n",
+  cat(paste0("The ", name, " dataset contains ", nrow(df), " records.\n",
             "Of which there are: \n", 
-            nrow(df %>% filter(included_column == 1)), "included records. \n",
-            nrow(df %>% filter(included_column == 0)), "excluded records.",
+            nrow(df %>% filter(included_column == 1)), " included records. \n",
+            nrow(df %>% filter(included_column == 0)), " excluded records.",
             "\n \n",
             "This dataset also contains:\n",
-            length(which(!is.na(df$title))), "/", nrow(df), "titles. \n",
-            length(which(!is.na(df$abstract))), "/", nrow(df), "abstracts. \n",
-            length(which(!is.na(df$doi))), "/", nrow(df), "doi's. \n"
+            length(which(!is.na(df$title))), "/", nrow(df), " titles, which is ", # number of titles
+            length(which(!is.na(df$title)))/nrow(df)*100,"%. \n",# percentage of present titles
+            length(which(!is.na(df$abstract))), "/", nrow(df), " abstracts, which is ", # number of abstracts
+            length(which(!is.na(df$abstract)))/nrow(df)*100 , "%. \n", # percentage of present abstracts
+            length(which(!is.na(df$doi))), "/", nrow(df), " doi's, which is ", # number of doi's
+            length(which(!is.na(df$doi)))/nrow(df)*100,"%. \n" # percentage of present doi's.
   ))
   
   


### PR DESCRIPTION
With this PR issue #4  is closed: However instead of a table, descriptive information is automatically returned on the console when running the commands in the scripts. 

The following descriptives are returned:
- Added in this specific PR: In `master_script_merging_after_asreview.R` information (number + percentage) on each of the three datasets and the merged dataset is returned regarding:
  - Inclusions
  - Exclusions 
  - Titles
  - Abstracts
  - DOI's
  
- In `crossref_doi_retrieval.ipynb` information is returned on the number and percentage of retrieved DOI's compared to the number of DOI's that was missing.
- In `master_script_deduplication.R` information is returned on the number and percentage ( percentage added in this PR) of records that were deduplicated both with and without label, for each deduplication strategy.
- In `master_script_quality_check.R` information is returned on the number and percentage (percentage added in this PR) of records that had their labels changed according to the quality checks.